### PR TITLE
Set `globalObject: "this"` for Node.js compat

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const CopyPlugin = require('copy-webpack-plugin');
+const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = {
   mode: "production",
@@ -34,9 +34,9 @@ module.exports = {
   plugins: [
     new CopyPlugin([
       {
-        from: 'src/index.d.ts',
-        to: 'index.d.ts',
-      },
-    ]),
-  ],
+        from: "src/index.d.ts",
+        to: "index.d.ts"
+      }
+    ])
+  ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ module.exports = {
   output: {
     library: "Skeleton",
     libraryTarget: "umd",
-    filename: "bundle.js"
+    filename: "bundle.js",
+    globalObject: "this"
   },
 
   externals: {


### PR DESCRIPTION
See https://webpack.js.org/configuration/output/#outputglobalobject

>To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'